### PR TITLE
Handle possibility of tokens not being available

### DIFF
--- a/javaparser-core/pom.xml
+++ b/javaparser-core/pom.xml
@@ -30,7 +30,7 @@
     </properties>
 
     <build>
-        <finalName>stubparser-3.20.2</finalName>
+        <finalName>stubparser-3.20.2.1</finalName>
         <plugins>
             <plugin>
                 <groupId>com.helger.maven</groupId>

--- a/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserBase.java
+++ b/javaparser-core/src/main/javacc-support/com/github/javaparser/GeneratedJavaParserBase.java
@@ -381,11 +381,11 @@ abstract class GeneratedJavaParserBase {
     Name scopeToName(Expression scope) {
         if (scope.isNameExpr()) {
             SimpleName simpleName = scope.asNameExpr().getName();
-            return new Name(simpleName.getTokenRange().get(), null, simpleName.getIdentifier());
+            return new Name(simpleName.getTokenRange().orElse(null), null, simpleName.getIdentifier());
         }
         if (scope.isFieldAccessExpr()) {
             FieldAccessExpr fieldAccessExpr = scope.asFieldAccessExpr();
-            return new Name(fieldAccessExpr.getTokenRange().get(), scopeToName(fieldAccessExpr.getScope()), fieldAccessExpr.getName().getIdentifier());
+            return new Name(fieldAccessExpr.getTokenRange().orElse(null), scopeToName(fieldAccessExpr.getScope()), fieldAccessExpr.getName().getIdentifier());
 
         }
         throw new IllegalStateException("Unexpected expression type: " + scope.getClass().getSimpleName());

--- a/readme.md
+++ b/readme.md
@@ -81,9 +81,11 @@ Give it a title like "Update to StubParser 3.10.2".
 ## Changes to StubParser that break the Checker Framework
 
 If you commit a change to the StubParser that breaks the Checker Framework,
-then update the stub parser version number.  In `javaparser-core/pom.xml`,
-increment the version number in the `<finalName>` block.
-Then update the Checker Framework to use this version of the stubparser.
+then change the StubParser version number.
+ * In `javaparser-core/pom.xml`, in the `<finalName>` block.
+ * In the Checker Framework's top-level `build.gradle` file, on the
+   `stubparserJar =` line.
+
 
 ## Original JavaParser README
 


### PR DESCRIPTION
Merge with https://github.com/typetools/checker-framework/pull/4582

The JavaParser team has let their pull request 3231 languish for 12 days.
This pull request gets the fix into Stubparser without waiting for them to review the pull request and make a release.