### PR TITLE
Fixed type parameters to be printed at the right place in records

### DIFF
--- a/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
+++ b/javaparser-core/src/main/java/com/github/javaparser/printer/DefaultPrettyPrinterVisitor.java
@@ -443,6 +443,8 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
 
         n.getName().accept(this, arg);
 
+        printTypeParameters(n.getTypeParameters(), arg);
+
         printer.print("(");
         if (!isNullOrEmpty(n.getParameters())) {
             for (final Iterator<Parameter> i = n.getParameters().iterator(); i.hasNext(); ) {
@@ -454,9 +456,7 @@ public class DefaultPrettyPrinterVisitor implements VoidVisitor<Void> {
             }
         }
         printer.print(")");
-
-        printTypeParameters(n.getTypeParameters(), arg);
-
+        
         if (!n.getImplementedTypes().isEmpty()) {
             printer.print(" implements ");
             for (final Iterator<ClassOrInterfaceType> i = n.getImplementedTypes().iterator(); i.hasNext(); ) {


### PR DESCRIPTION
They should be printed before the record header with the fields, not after the header.

