### PR TITLE
Allow compact record constructors to be missing a body, for parsing stubs

### DIFF
--- a/javaparser-core/src/main/javacc/java.jj
+++ b/javaparser-core/src/main/javacc/java.jj
@@ -1874,7 +1874,7 @@ BodyDeclaration<?> RecordBodyDeclaration():
             ret = AnnotationTypeDeclaration(modifiers)
          |
             // Compact Record Constructors
-            LOOKAHEAD( [ TypeParameters() ] Identifier() "{" )
+            LOOKAHEAD( [ TypeParameters() ] Identifier() ("{" | ";") ) // stub files may omit method and constructor bodies
             ret = CompactConstructorDeclaration(modifiers)
          |
             // "Normal" Record Constructors
@@ -1921,13 +1921,14 @@ CompactConstructorDeclaration CompactConstructorDeclaration(ModifierHolder modif
         throwType = AnnotatedReferenceType() { throws_ = add(throws_, throwType); }
         ("," throwType = AnnotatedReferenceType() { throws_ = add(throws_, throwType); })*
     ]
+    ( ";" | // stub files may omit method and constructor bodies
     "{" { blockBegin=token(); }
     [
         LOOKAHEAD(ExplicitConstructorInvocation())
         exConsInv = ExplicitConstructorInvocation()
     ]
     stmts = Statements()
-    "}"
+    "}" )
 
     {
     if (exConsInv != null) {


### PR DESCRIPTION
A change to the stub parser to allow compact record constructors to lack a body.  This lets you write stubs like:

```
public record Foo(int x) {
    @MyConstructorAnnotation Foo;
}
```

It feels a bit strange to allow annotations on a single word without a sign to the parser that it's a constructor, but I don't think it's ambiguous because every field needs a type, and all other methods and constructors need parentheses.  The only other way I can see to do it is to require the empty curly brackets instead -- which I would personally be fine with, but the approach in this PR felt more consistent with the way stubs usually work.